### PR TITLE
feat(tracing): get span data

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -1056,24 +1055,24 @@ func HTTPtoSpanStatus(code int) SpanStatus {
 func GetSpanData[T any](s *Span, name string) (T, error) {
 	var zero T
 	if s == nil {
-		return zero, errors.New("span is nil")
+		return zero, fmt.Errorf("failed to get span data: span is nil")
 	}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	if s.Data == nil {
-		return zero, errors.New("span data is nil")
+		return zero, fmt.Errorf("failed to get span data: span data is nil")
 	}
 
 	value, exists := s.Data[name]
 	if !exists {
-		return zero, errors.New("key does not exist")
+		return zero, fmt.Errorf("failed to get span data: key %s does not exist", name)
 	}
 
 	typedValue, ok := value.(T)
 	if !ok {
-		return zero, errors.New("value is not of type T")
+		return zero, fmt.Errorf("failed to get span data: attribute %s has type %T, expected %T", name, value, zero)
 	}
 
 	return typedValue, nil


### PR DESCRIPTION
- GetSpanData to get data from a span using a generic approach
- New TestGetSpanData to guard the function from various scenarios

Why Generic? 
- I usually do not store complex data in the span, hence this approach is good with less footprint and maintenance burden compared to Otel's approach mentioned [in the issue](https://github.com/getsentry/sentry-go/issues/991)

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
